### PR TITLE
feat: add clone-and-path installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,29 @@ Git worktreeの一般的な問題を解決する拡張管理ツール：
 
 ## Installation / インストール
 
-### Manual Install / 手動インストール
+### Method 1: Clone and Add to PATH (Recommended) / 方法1: クローンしてPATHに追加（推奨）
+
+Simply clone the repository and add it to your PATH:
+リポジトリをクローンしてPATHに追加するだけです：
+
+```bash
+git clone https://github.com/Pregum/git-worktree-sync.git ~/git-worktree-sync
+echo 'export PATH="$PATH:$HOME/git-worktree-sync"' >> ~/.bashrc  # or ~/.zshrc
+source ~/.bashrc  # or source ~/.zshrc
+```
+
+This method allows you to easily update by pulling the latest changes:
+この方法では、最新の変更をプルして簡単に更新できます：
+
+```bash
+cd ~/git-worktree-sync
+git pull
+```
+
+### Method 2: Traditional Install / 方法2: 従来のインストール
+
+Use the install script to copy the executable to a system directory:
+インストールスクリプトを使用して実行ファイルをシステムディレクトリにコピーします：
 
 ```bash
 git clone https://github.com/Pregum/git-worktree-sync.git
@@ -49,10 +71,13 @@ export PATH="$PATH:$HOME/bin"
 
 ## Configuration / 設定
 
-### Config File / 設定ファイル
+**Note:** Configuration files are optional. The tool works with sensible defaults out of the box.
+**注意:** 設定ファイルは任意です。このツールはデフォルト設定でそのまま動作します。
 
-Create `~/.git-worktree-sync.conf`:
-`~/.git-worktree-sync.conf`を作成：
+### Config File (Optional) / 設定ファイル（オプション）
+
+Create `~/.git-worktree-sync.conf` to customize behavior:
+動作をカスタマイズするには`~/.git-worktree-sync.conf`を作成します：
 
 ```bash
 # Base directory for worktrees

--- a/install.sh
+++ b/install.sh
@@ -20,12 +20,12 @@ fi
 cp -f "$SCRIPT_DIR/$COMMAND_NAME" "$INSTALL_DIR/"
 chmod +x "$INSTALL_DIR/$COMMAND_NAME"
 
-# Create config file if it doesn't exist
+# Create config file if it doesn't exist (optional)
 CONFIG_FILE="$HOME/.git-worktree-sync.conf"
 if [[ ! -f "$CONFIG_FILE" ]]; then
-    echo "Creating default configuration file at $CONFIG_FILE"
-    cp "$SCRIPT_DIR/.git-worktree-sync.conf.example" "$CONFIG_FILE"
-    echo "Please edit $CONFIG_FILE to customize your settings"
+    echo ""
+    echo "Note: You can optionally create a configuration file at $CONFIG_FILE"
+    echo "See the README for configuration options."
 fi
 
 # Check if install directory is in PATH


### PR DESCRIPTION
## Summary

This PR adds support for installing git-worktree-sync by simply cloning and adding to PATH, without requiring the install.sh script.

## Changes

• **New installation method**: Added "Clone and Add to PATH" as the recommended installation method
• **Configuration clarification**: Made it clear that configuration files are completely optional
• **Install script fix**: Fixed install.sh removing the non-existent sample config file copy attempt
• **Documentation updates**: Updated README to emphasize that the tool works out-of-the-box

## Benefits

1. **Simpler installation**: No need to run install scripts or have sudo access
2. **Easier updates**: Users can update with a simple `git pull`
3. **Clearer expectations**: Documentation now clearly states config files are optional

## Example Usage

```bash
# Install
git clone https://github.com/Pregum/git-worktree-sync.git ~/git-worktree-sync
echo 'export PATH="$PATH:$HOME/git-worktree-sync"' >> ~/.bashrc
source ~/.bashrc

# Update
cd ~/git-worktree-sync
git pull
```

🤖 Generated with [Claude Code](https://claude.ai/code)